### PR TITLE
Bugfix: Edit command unable to create investment plan tags

### DIFF
--- a/src/main/java/seedu/fast/model/tag/Tag.java
+++ b/src/main/java/seedu/fast/model/tag/Tag.java
@@ -12,8 +12,8 @@ public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric "
             + "and not more than 20 characters long,\nor follow the specified"
-            + "format for a PriorityTag (\"pr/\" followed by low, med or high)\nor a InvestmentPlanTag " +
-            "(\"ip/\" followed by health, invest, life, motor, property, save or travel)";
+            + "format for a PriorityTag (\"pr/\" followed by low, med or high)\nor a InvestmentPlanTag "
+            + "(\"ip/\" followed by health, invest, life, motor, property, save or travel)";
 
 
     public static final String MESSAGE_USAGE = "tag: label a client with a keyword or term. \n"


### PR DESCRIPTION
Fixed an issue where the error message was missing the commands for InvestmentPlanTags
Fixed an issue where EditCommand was unable to create InvestmentPlanTags despite correct syntax being used 